### PR TITLE
Exception has been thrown in "beforeScenario" hook

### DIFF
--- a/src/Knp/FriendlyContexts/Symfony/Profiler/Collector.php
+++ b/src/Knp/FriendlyContexts/Symfony/Profiler/Collector.php
@@ -19,7 +19,7 @@ class Collector
     {
         $tokens = array_map(
             function ($e) { return $e['token']; },
-            $this->profiler->find('', '', 100, '')
+            $this->profiler->find('', '', 100, '', null, null)
         );
 
         $tokens = array_diff($tokens, $this->tokens);


### PR DESCRIPTION
The error I was getting with symfony 2.3:

```
[Behat\Behat\Exception\ErrorException]                                                                                                                               
  Exception has been thrown in "beforeScenario" hook, defined in Knp\FriendlyContexts\Context\SwiftMailerContext::initContext()                                        

  Notice: Undefined variable: start in vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Profiler/Profiler.php line 175
```
