### PR TITLE
Make the response object protected in ApiContext

### DIFF
--- a/src/Knp/FriendlyContexts/Context/ApiContext.php
+++ b/src/Knp/FriendlyContexts/Context/ApiContext.php
@@ -8,7 +8,7 @@ use Guzzle\Http\Exception\BadResponseException;
 
 class ApiContext extends RawPageContext
 {
-    private $response;
+    protected $response;
 
     /**
      * @Given /^I prepare a (?<method>[A-Za-z]+) request on "(?<page>[^"].*)"?$/


### PR DESCRIPTION
If extending the ApiContext, which is cool if you want to implement more custom tests on the response object, the response should be protected so it can be accessed from sub-classes.
