### PR TITLE
Fix use of postBody

### DIFF
--- a/src/Knp/FriendlyContexts/Builder/PostRequestBuilder.php
+++ b/src/Knp/FriendlyContexts/Builder/PostRequestBuilder.php
@@ -10,6 +10,7 @@ class PostRequestBuilder extends AbstractRequestBuilder
         parent::build($uri, $queries, $headers, $postBody, $body, $options);
 
         $resource = $queries ? sprintf('%s?%s', $uri, $this->formatQueryString($queries)) : $uri;
+        $postBody = $postBody ?: $body;
 
         return $this->client->post($resource, $headers, $postBody, $options);
     }


### PR DESCRIPTION
When using "I specified the following request body:" step (ApiContext), $body is not passed to the client.

This solution is not the cleanest but it works for now since you usually don't provide form data and for ex. JSON data in same request.
