### PR TITLE
[TableContext] Fix incorrect behaviour of iShouldSeeATableWithInTheNamedColumn

### DIFF
--- a/src/Knp/FriendlyContexts/Context/TableContext.php
+++ b/src/Knp/FriendlyContexts/Context/TableContext.php
@@ -13,9 +13,10 @@ class TableContext extends RawMinkContext
      */
     public function iShouldSeeATableWithInTheNamedColumn($list, $column)
     {
-        $expected = array_merge(array($column), $this->getFormater()->listToArray($list));
+        $cells = array_merge(array($column), $this->getFormater()->listToArray($list));
+        $expected = new TableNode(array_map(function($cell) { return [$cell]; }, $cells));
 
-        $this->iShouldSeeTheFollowingTable(array($expected));
+        $this->iShouldSeeTheFollowingTable($expected);
     }
 
     /**


### PR DESCRIPTION
Fixes #116, if that happens to be necessary, by checking for column existence instead of for row. 