### PR TITLE
Added method to EntityContext to check data from stored Entities

### DIFF
--- a/doc/context-entity.md
+++ b/doc/context-entity.md
@@ -187,6 +187,19 @@ Same thing for deletion
   Then I should see "Your user is deleted"
   And 1 user should have been deleted # <= this is the step
 ```
+
+**Sometimes you may want to check that a user created or modified has the correct data stored in the database
+
+Check it doing
+```gherkin
+  When I open the form
+  And I fill in the form with "Albert" "Einstein" "Scientist" values
+  And I press "Submit"
+  Then should be 1 user like:
+    | firstname | lastname | profession |
+    | Albert    | Einstein | Scientist  |
+```
+
 Reset Schema
 ------------
 You just have to use the tag **@reset-schema**

--- a/spec/Knp/FriendlyContexts/Context/EntityContextSpec.php
+++ b/spec/Knp/FriendlyContexts/Context/EntityContextSpec.php
@@ -2,10 +2,14 @@
 
 namespace spec\Knp\FriendlyContexts\Context;
 
+use Behat\Gherkin\Node\TableNode;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Knp\FriendlyContexts\Doctrine\EntityResolver;
 use Knp\FriendlyContexts\Utils\Asserter;
 use Knp\FriendlyContexts\Utils\TextFormater;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 class EntityContextSpec extends ObjectBehavior
 {
@@ -67,7 +71,7 @@ class EntityContextSpec extends ObjectBehavior
         $this->shouldThrow(new \Exception('2 entities should have been deleted, 0 actually', 1))->duringEntitiesShouldHaveBeen('2', 'entities', 'deleted');
     }
 
-    function it_should_assert_a_creation($collection, $entity3)
+    function it_should_assert_a_creation($collection)
     {
         $collection->attach('e1')->shouldNotBeCalled();
         $collection->attach('e2')->shouldNotBeCalled();
@@ -75,5 +79,85 @@ class EntityContextSpec extends ObjectBehavior
 
         $this->entitiesShouldHaveBeen('1', 'entities', 'created')->shouldReturn(null);
         $this->shouldThrow(new \Exception('0 entities should have been created, 1 actually', 1))->duringEntitiesShouldHaveBeen('no', 'entities', 'created');
+    }
+
+    function it_should_throw_an_exception_if_no_existence(
+        EntityResolver $resolver,
+        TableNode $tableNode,
+        $repository,
+        $manager,
+        ClassMetadata $metadata
+    ) {
+        $resolver->resolve(Argument::cetera())->willReturn([$metadata]);
+        $metadata->getName()->willReturn("EntityStub");
+
+        $tableNode->getRows()->willReturn(array(
+            array('header', 'header'),
+            array('value', 'value'),
+        ));
+
+        $manager->getRepository(Argument::any())->willReturn($repository);
+        $manager->getClassMetadata(Argument::any())->willReturn($metadata);
+        $metadata->getIdentifierFieldNames()->willReturn([]);
+        $repository->findOneBy(Argument::any())->willReturn(null);
+
+        $this->shouldThrow(new \Exception("There is not any object for the following identifiers: []"))->duringExistLikeFollowing(1, "Class", $tableNode);
+    }
+
+    function it_should_throw_exception_if_some_expected_value_is_not_found(
+        EntityResolver $resolver,
+        TableNode $tableNode,
+        $manager,
+        $repository,
+        ClassMetadata $metadata,
+        PropertyAccessor $accessor
+    ) {
+        $className = "EntityStub";
+
+        $resolver->resolve(Argument::cetera())->willReturn([$metadata]);
+        $metadata->getName()->willReturn($className);
+
+        $tableNode->getRows()->willReturn(array(
+            array('correctProperty', 'incorrectProperty'),
+            array('correct_value', 'incorrect_value'),
+        ));
+
+        // Instance needed since PropertyAccessor is created inside the tested method
+        $entityStub = new EntityStub('correct_value', 'another_incorrect_value');
+
+        $manager->getRepository($className)->willReturn($repository);
+        $manager->getClassMetadata($className)->willReturn($metadata);
+        $metadata->getIdentifierFieldNames()->willReturn([]);
+        $repository->findOneBy([])->willReturn($entityStub);
+
+        $manager->refresh($entityStub)->shouldBeCalled();
+
+        $accessor->getValue($entityStub, 'correctProperty')->willReturn('correct_value');
+        $accessor->getValue($entityStub, 'incorrectProperty')->willReturn('another_incorrect_value');
+
+        $this->shouldThrow(new \Exception("The expected object does not have property incorrectProperty with value incorrect_value"))->duringExistLikeFollowing(1, "EntityStub", $tableNode);
+    }
+}
+
+class EntityStub
+{
+    private $correctProperty;
+
+    private $incorrectProperty;
+
+    public function __construct($correct, $incorrect)
+    {
+        $this->correctProperty = $correct;
+        $this->incorrectProperty = $incorrect;
+    }
+
+    public function getCorrectProperty()
+    {
+        return $this->correctProperty;
+    }
+
+    public function getIncorrectProperty()
+    {
+        return $this->incorrectProperty;
     }
 }

--- a/spec/Knp/FriendlyContexts/Context/EntityContextSpec.php
+++ b/spec/Knp/FriendlyContexts/Context/EntityContextSpec.php
@@ -109,8 +109,7 @@ class EntityContextSpec extends ObjectBehavior
         TableNode $tableNode,
         $manager,
         $repository,
-        ClassMetadata $metadata,
-        PropertyAccessor $accessor
+        ClassMetadata $metadata
     ) {
         $className = "EntityStub";
 
@@ -131,9 +130,6 @@ class EntityContextSpec extends ObjectBehavior
         $repository->findOneBy([])->willReturn($entityStub);
 
         $manager->refresh($entityStub)->shouldBeCalled();
-
-        $accessor->getValue($entityStub, 'correctProperty')->willReturn('correct_value');
-        $accessor->getValue($entityStub, 'incorrectProperty')->willReturn('another_incorrect_value');
 
         $this->shouldThrow(new \Exception("The expected object does not have property incorrectProperty with value incorrect_value"))->duringExistLikeFollowing(1, "EntityStub", $tableNode);
     }

--- a/src/Knp/FriendlyContexts/Context/EntityContext.php
+++ b/src/Knp/FriendlyContexts/Context/EntityContext.php
@@ -5,6 +5,7 @@ namespace Knp\FriendlyContexts\Context;
 use Behat\Gherkin\Node\TableNode;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class EntityContext extends Context
 {
@@ -151,6 +152,41 @@ class EntityContext extends Context
     }
 
     /**
+     * @Then /^should be (\d+) (.*) like:?$/
+     */
+    public function existLikeFollowing($nbr, $name, TableNode $table)
+    {
+        $entityName = $this->resolveEntity($name)->getName();
+
+        $rows = $table->getRows();
+        $headers = array_shift($rows);
+
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        for ($i = 0; $i < $nbr; $i++) {
+            $row = $rows[$i % count($rows)];
+
+            $values = array_combine($headers, $row);
+            $object = $this->getEntityManager()
+                ->getRepository($entityName)
+                ->findOneBy(
+                    $this->getEntityIdentifiers($entityName, $headers, $row)
+                );
+
+            if (is_null($object)) {
+                throw new \Exception(sprintf("There is not any object for the following identifiers: %s", json_encode($this->getEntityIdentifiers($entityName, $headers, $row))));
+            }
+            $this->getEntityManager()->refresh($object);
+
+            foreach ($values as $key => $value) {
+                if ($value != $accessor->getValue($object, $key) ) {
+                    throw new \Exception("The expected object does not have property $key with value $value");
+                }
+            }
+        }
+    }
+
+    /**
      * @BeforeScenario
      */
     public function beforeScenario($event)
@@ -213,5 +249,27 @@ class EntityContext extends Context
         return [
             'Entities' => [''],
         ];
+    }
+
+    /**
+     * @param string $entityName
+     * @param array $headers Headers of the Behat TableNode
+     * @param array $row current row if tge Behat TableNode
+     * @return array ['id_column_A' => 'value', 'id_column_B' => 'value']
+     * @throws \Exception
+     */
+    protected function getEntityIdentifiers($entityName, $headers, $row)
+    {
+        $metadata = $this->getEntityManager()->getClassMetadata($entityName);
+        $identifiers = $metadata->getIdentifierFieldNames();
+
+        $identifiersWithValues = [];
+
+        foreach ($identifiers as $identifier) {
+            $headersPosition = array_search($identifier, $headers);
+            $identifiersWithValues[$identifier] = $row[$headersPosition];
+        }
+
+        return $identifiersWithValues;
     }
 }


### PR DESCRIPTION
I propose to include a new step in the `EntityContext` to be able to check if some record is registered in the database, matching by specified field.
In my case, we needed to check if a record or a modification is done correctly by checking the properties of the entity, something cannot be done with the current steps.
Hope you find it interesting.