### PR TITLE
Provided a way to retrieve response from context

### DIFF
--- a/src/Knp/FriendlyContexts/Context/ApiContext.php
+++ b/src/Knp/FriendlyContexts/Context/ApiContext.php
@@ -11,6 +11,11 @@ class ApiContext extends RawPageContext
 {
     protected $response;
 
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
     /**
      * @Given /^I prepare a (?<method>[A-Za-z]+) request on "(?<page>[^"].*)?"$/
      * @Given /^I prepare a (?<method>[A-Za-z]+) request on the (.*) (?<hasPage>page|resource)$/


### PR DESCRIPTION
This is usefull for custom checking.

For example, if you want to do more advanced checking in your project context, you could gather the ApiContext and grab the response from here like so (shamelessly copied from https://gist.github.com/stof/930e968829cd66751a3a):

``` php
<?php

namespace Context;

use Behat\Behat\Tester\Exception\PendingException;
use Behat\Behat\Context\SnippetAcceptingContext;
use Behat\Behat\Hook\Scope\BeforeScenarioScope;

class FeatureContext implements SnippetAcceptingContext
{
    protected $apiContext;

    /**
     * @BeforeScenario
     */
    public function gatherApiContext(BeforeScenarioScope $scope)
    {
        $environment = $scope->getEnvironment();

        $this->apiContext = $environment->getContext('Knp\FriendlyContexts\Context\ApiContext');
    }

    /**
     * @Then the response should contains :count elements in the :key key
     */
    public function theResponseShouldContainsElementsInTheKey($count, $key)
    {
        $response = $this->apiContext->getResponse();
        // Check whatever you want
    }
}
```

Pretty useful don't you think?