### PR TITLE
Fix friendly.guesser.decimal missing faker

### DIFF
--- a/src/Knp/FriendlyContexts/services/fakers.yml
+++ b/src/Knp/FriendlyContexts/services/fakers.yml
@@ -65,7 +65,7 @@ services:
             - { name: friendly.guesser.smallint.faker }
             - { name: friendly.guesser.int.faker }
             - { name: friendly.guesser.bigint.faker }
-            - { name: friendly.guesser.float.faker }
+            - { name: friendly.guesser.decimal.faker }
 
     friendly.faker.payment:
         class: Knp\FriendlyContexts\Faker\Provider\Payment


### PR DESCRIPTION
This patch fix errors occuring when using `EntityContext::theFollowing()` where `DecimalGuesser::fake()` fail not having fakers. see #133

The tags used on `friendly.faker.miscellaneous` definition include `friendly.guesser.float.faker`.

```yaml
    friendly.faker.miscellaneous:
        class: Knp\FriendlyContexts\Faker\Provider\Miscellaneous
        arguments:
            - @friendly.faker
        tags:
            # ...
            - { name: friendly.guesser.float.faker }
```

This particular tag does not refer to a valid guesser (see [`FormatGuesserPass`](https://github.com/KnpLabs/FriendlyContexts/blob/master/src/Knp/FriendlyContexts/DependencyInjection/Compiler/FormatGuesserPass.php)), as `float` are managed by the [`friendly.guesser.decimal`](https://github.com/KnpLabs/FriendlyContexts/blob/master/src/Knp/FriendlyContexts/Guesser/DecimalGuesser.php)

By using `friendly.guesser.decimal.faker` tag instead of `friendly.guesser.float.faker`, the problem is solved.