### PR TITLE
allow the indifferent use of singular and plural

### DIFF
--- a/src/Knp/FriendlyContexts/Context/EntityContext.php
+++ b/src/Knp/FriendlyContexts/Context/EntityContext.php
@@ -45,7 +45,7 @@ class EntityContext extends Context
     }
 
     /**
-     * @Given /^there is (\d+) ((?!\w* like)\w*)$/
+     * @Given /^there (?:is|are) (\d+) ((?!\w* like)\w*)$/
      */
     public function thereIs($nbr, $name)
     {
@@ -70,7 +70,7 @@ class EntityContext extends Context
     }
 
     /**
-     * @Given /^there is (\d+) (.*) like:?$/
+     * @Given /^there (?:is|are) (\d+) (.*) like:?$/
      */
     public function thereIsLikeFollowing($nbr, $name, TableNode $table)
     {


### PR DESCRIPTION
In the nice talk about FriendlyContexts by @Nek- yesterday at the sfPot, I started to feel some blood dripping from my eyes when looking at one of the slides, which read : 

> Given there is 100 products

As a good grammar nazi, I think people should be offered the possibility to call this step definition with steps that are grammatically correct.

Not sure it works though, I have never used `?:` before, and it looks like there are no tests that cover this (why not ?).