### PR TITLE
Add missing backslash to InvalidArgumentException

### DIFF
--- a/src/Knp/FriendlyContexts/Context/ApiContext.php
+++ b/src/Knp/FriendlyContexts/Context/ApiContext.php
@@ -235,7 +235,7 @@ class ApiContext extends RawPageContext
         }
 
         if (false === $jsonData) {
-            throw new InvalidArgumentException(sprintf(
+            throw new \InvalidArgumentException(sprintf(
                 'Invalid json data class ("%s")',
                 get_class($jsonData)
             ));


### PR DESCRIPTION
Added missing backslash when throwing an `InvalidArgumentException` in the ApiContext