### PR TITLE
Update MinkContext to not escape locator to named + update doc

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -4,7 +4,7 @@ Installation
 Execute
 
 ```
-execute : composer require knplabs/friendly-contexts dev-master
+composer require knplabs/friendly-contexts dev-master
 ```
 
 Edit behat.yml
@@ -24,3 +24,20 @@ default:
         Knp\FriendlyContexts\Extension: ~
 ```
 
+###Kernel configuration
+
+If you have some fancy kernel configuration, you can just set it like this (`shown values are default`):
+
+```yaml
+default:
+    # ...
+    extensions:
+        # ...
+        Knp\FriendlyContexts\Extension:
+            symfony_kernel:
+                bootstrap: app/autoload.php
+                path: app/AppKernel.php
+                class: AppKernel
+                env: test
+                debug: true
+```

--- a/src/Knp/FriendlyContexts/Context/MinkContext.php
+++ b/src/Knp/FriendlyContexts/Context/MinkContext.php
@@ -149,7 +149,7 @@ class MinkContext extends BaseMinkContext
         $locator = $this->fixStepArgument($locator);
 
         $elements = $parent->findAll('named', array(
-            $element, $this->getSession()->getSelectorsHandler()->xpathLiteral($locator)
+            $element, $locator
         ));
 
         if (null !== $filterCallback && is_callable($filterCallback)) {


### PR DESCRIPTION
Passing an escaped locator to the named selector is deprecated as of 1.7 and will be removed in 2.0. Pass the raw value instead. in `vendor/behat/mink/src/Selector/NamedSelector.php` line 256