### PR TITLE
Update MinkContext to not escape locator to named

### DIFF
--- a/src/Knp/FriendlyContexts/Context/MinkContext.php
+++ b/src/Knp/FriendlyContexts/Context/MinkContext.php
@@ -149,7 +149,7 @@ class MinkContext extends BaseMinkContext
         $locator = $this->fixStepArgument($locator);
 
         $elements = $parent->findAll('named', array(
-            $element, $this->getSession()->getSelectorsHandler()->xpathLiteral($locator)
+            $element, $locator
         ));
 
         if (null !== $filterCallback && is_callable($filterCallback)) {


### PR DESCRIPTION
Passing an escaped locator to the named selector is deprecated as of 1.7 and will be removed in 2.0. Pass the raw value instead. in `vendor/behat/mink/src/Selector/NamedSelector.php` line 256