### PR TITLE
Fix Symfony 2.7 factory warning

### DIFF
--- a/src/Knp/FriendlyContexts/services/core.yml
+++ b/src/Knp/FriendlyContexts/services/core.yml
@@ -62,8 +62,7 @@ services:
 
     friendly.faker:
         class: Faker\Generator
-        factory_class: Faker\Factory
-        factory_method: create
+        factory: [Faker\Factory, create]
 
     friendly.page.resolver:
         class: Knp\FriendlyContexts\Page\Resolver\PageClassResolver


### PR DESCRIPTION
Fix Symfony 2.7 factory warning.
Related to #152 