### PR TITLE
Fix "contains" typos

### DIFF
--- a/doc/context-api.md
+++ b/doc/context-api.md
@@ -63,9 +63,9 @@ Then I should receive a 200 response # Assert that the response code is 200
 Then I should receive a 200 json response # Assert that the response  code is 2OO and the content type is a valid json
 
 # assert headers, and data content
-Then the response should contains the following headers:
+Then the response should contain the following headers:
     | Cache-Control | max-age=21600 |
-Then the response should contains the following json:
+Then the response should contain the following json:
     """
     {
         "plop": {
@@ -74,7 +74,7 @@ Then the response should contains the following json:
         }
     }
     """
-Then the response should contains:
+Then the response should contain:
     """
     <?xml version="1.0" encoding="UTF-8"?>
     <some-data>

--- a/spec/Knp/FriendlyContexts/Utils/AsserterSpec.php
+++ b/spec/Knp/FriendlyContexts/Utils/AsserterSpec.php
@@ -47,7 +47,7 @@ class AsserterSpec extends ObjectBehavior
 
     function it_assert_that_an_array_contains_an_other()
     {
-        $expected = "The given array\r\n\r\n| 10 | test | 1 |\r\ndoes not contains the following rows\r\n\r\n| 10 | text |  |";
+        $expected = "The given array\r\n\r\n| 10 | test | 1 |\r\ndoes not contain the following rows\r\n\r\n| 10 | text |  |";
 
         $this->shouldThrow(new \Exception($expected, 1))->duringAssertArrayContains([ 10, 'text', false ], [ 10, 'test', true ]);
     }
@@ -76,7 +76,7 @@ class AsserterSpec extends ObjectBehavior
         $this->assertArrayContains($expected, $real)->shouldReturn(true);
     }
 
-    function it_throw_when_array_doesnt_contains()
+    function it_throw_when_array_doesnt_contain()
     {
         $real = [
             [ 1, 2, 3, 4 ],

--- a/src/Knp/FriendlyContexts/Context/ApiContext.php
+++ b/src/Knp/FriendlyContexts/Context/ApiContext.php
@@ -200,7 +200,7 @@ class ApiContext extends RawPageContext
     }
 
     /**
-     * @Then /^the response should contains the following headers:?$/
+     * @Then /^the response should contains? the following headers:?$/
      */
     public function theResponseShouldContainsHeaders(TableNode $headerTable)
     {
@@ -216,7 +216,7 @@ class ApiContext extends RawPageContext
     }
 
     /**
-     * @Then /^the response should contains the following json:?$/
+     * @Then /^the response should contains? the following json:?$/
      */
     public function theResponsShouldContainsJson($jsonData)
     {
@@ -255,7 +255,7 @@ class ApiContext extends RawPageContext
     }
 
     /**
-     * @Then /^the response should contains:?$/
+     * @Then /^the response should contains?:?$/
      */
     public function theResponseShouldContains(PyStringNode $bodyNode)
     {

--- a/src/Knp/FriendlyContexts/Utils/Asserter.php
+++ b/src/Knp/FriendlyContexts/Utils/Asserter.php
@@ -34,7 +34,7 @@ class Asserter
 
     public function assertArrayContains(array $expected, array $real, $message = null)
     {
-        $message = $message ?: sprintf("The given array\r\n\r\n%s\r\ndoes not contains the following rows\r\n\r\n%s", $this->explode($real), $this->explode($expected));
+        $message = $message ?: sprintf("The given array\r\n\r\n%s\r\ndoes not contain the following rows\r\n\r\n%s", $this->explode($real), $this->explode($expected));
         $indexes = [];
 
         foreach ($expected as $row) {


### PR DESCRIPTION
I let the possibility to use "should contains" and I did not touch context method names not to break BC.