### PR TITLE
Remove outdated warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "doctrine/data-fixtures": "~1.0",
         "behat/mink-extension": "~2.0",
         "fzaninotto/faker": "~1.0",
-        "nelmio/alice": "~1.0",
+        "nelmio/alice": "~1.7",
         "guzzle/guzzle": "~3.7"
     },
     "require-dev": {

--- a/doc/context-alice.md
+++ b/doc/context-alice.md
@@ -2,8 +2,6 @@ Alice Context
 =============
 This context use the [nelmio/alice](https://github.com/nelmio/alice) fixture loading system.
 
->**Warning** : Alice context is compatible with Alice since **[this commit](https://github.com/nelmio/alice/commit/ae478b9f8abe587c30454b8ad93505642f93a42e)**. For the moment, you have to follow dev-master branch of nelmio/alice.
-
 
 Configuration
 -------------


### PR DESCRIPTION
The commit appears in stable versions of alice