### PR TITLE
Forced kernel to boot to match logic in Context

### DIFF
--- a/src/Knp/FriendlyContexts/Alice/ProviderResolver.php
+++ b/src/Knp/FriendlyContexts/Alice/ProviderResolver.php
@@ -78,6 +78,7 @@ class ProviderResolver
         }
 
         $kernel = $this->container->get('friendly.symfony.kernel');
+        $kernel->boot();
 
         if (false === $kernel->getContainer()->has($service)) {
 


### PR DESCRIPTION
Using Alice without using any other contexts produces the following error:

```
PHP Fatal error:  Call to a member function has() on null in knplabs/friendly-contexts/src/Knp/FriendlyContexts/Alice/ProviderResolver.php on line 82
```

This error is caused because `ProviderResolver` assumes the kernel has been booted (and in-order for `$kernel->getContainer()` to work). This probably doesn't affect most people because if you use another hook first (i.e. reset-schema) then the kernel is booted by the [abstract Context](https://github.com/KnpLabs/FriendlyContexts/blob/master/src/Knp/FriendlyContexts/Context/Context.php#L126). But if you choose to perform your own reset of the schema, then you'll run into this error.
