### PR TITLE
Manage PoolingShardConnection on @reset-schema tag

### DIFF
--- a/src/Knp/FriendlyContexts/Context/EntityContext.php
+++ b/src/Knp/FriendlyContexts/Context/EntityContext.php
@@ -195,7 +195,7 @@ class EntityContext extends Context
         if ($this->hasTags([ 'reset-schema', '~not-reset-schema' ])) {
             foreach ($this->getEntityManagers() as $name => $entityManager) {
                 $connection = $entityManager->getConnection();
-                if ($connection instanceof PoolingShardConnection) {
+                if ($connection instanceof PoolingShardConnection && $this->hasTag('reset-shard-schema')) {
                     $poolingShardManager = $this->getPoolingShardManager($connection);
                     foreach ($poolingShardManager->getShards() as $shardId) {
                         // Switch to shard database
@@ -204,9 +204,8 @@ class EntityContext extends Context
                     }
                     // Back to global
                     $connection->connect(0);
-                } else {
-                    $this->resetSchema($entityManager);
                 }
+                $this->resetSchema($entityManager);
             }
         }
     }


### PR DESCRIPTION
Also add `@reset-shard-schema` tag for performances. By default, it ignores shard databases and only reset global database. If this tag is present, shard databases are also reset
