### PR TITLE
Modify schema update to now simply delete the whole db

### DIFF
--- a/src/Knp/FriendlyContexts/Context/EntityContext.php
+++ b/src/Knp/FriendlyContexts/Context/EntityContext.php
@@ -3,6 +3,7 @@
 namespace Knp\FriendlyContexts\Context;
 
 use Behat\Gherkin\Node\TableNode;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -189,14 +190,12 @@ class EntityContext extends Context
         $this->storeTags($event);
 
         if ($this->hasTags([ 'reset-schema', '~not-reset-schema' ])) {
-            foreach ($this->getEntityManagers() as $entityManager) {
-                $metadata = $this->getMetadata($entityManager);
+            $purger = new ORMPurger();
+            $purger->setPurgeMode(ORMPurger::PURGE_MODE_DELETE);
 
-                if (!empty($metadata)) {
-                    $tool = new SchemaTool($entityManager);
-                    $tool->dropSchema($metadata);
-                    $tool->createSchema($metadata);
-                }
+            foreach ($this->getEntityManagers() as $entityManager) {
+                $purger->setEntityManager($entityManager);
+                $purger->purge();
             }
         }
 


### PR DESCRIPTION
This is about #195

Q | A
-------- 
BC Break? | yes
new feature? | no
bug fix? | yes
test pass? | not testable with phpspec (the old method was not either)
fix ticket? | #195

Please notice that I could make another tag like `@reset-database` which will not break the compatibiity. (it breaks on schema generation, after this patch you need to generate the schema before your test suite)