### PR TITLE
Fix composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "guzzle/guzzle": "~3.7"
     },
     "require-dev": {
-        "phpspec/phpspec": "2.0.*@dev",
-        "doctrine/orm": "dev-master",
+        "phpspec/phpspec": "~2.4|~3.0",
+        "doctrine/orm": "~2.5",
         "knplabs/phpspec-welldone-extension": "dev-master"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "doctrine/inflector": "~1.0",
         "doctrine/data-fixtures": "~1.0",
         "behat/mink-extension": "~2.0",
-        "fzaninotto/faker": "~1.3",
+        "fzaninotto/faker": "~1.4",
         "nelmio/alice": "~2.0",
         "guzzle/guzzle": "~3.7"
     },


### PR DESCRIPTION
- dev-master was used before for doctrine/orm. Stick to ~2.5 now.
- allows phpspec ~2.4|~3.0 to work with typehints in PHP7.0
- faker is now ~1.4