### PR TITLE
Import OauthExtension in ApiContext to prevent fatal error

### DIFF
--- a/src/Knp/FriendlyContexts/Context/ApiContext.php
+++ b/src/Knp/FriendlyContexts/Context/ApiContext.php
@@ -6,6 +6,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Gherkin\Node\PyStringNode;
 use Guzzle\Http\Exception\BadResponseException;
 use Knp\FriendlyContexts\Http\Security\HttpExtension;
+use Knp\FriendlyContexts\Http\Security\OauthExtension;
 
 class ApiContext extends RawPageContext
 {


### PR DESCRIPTION
Import OAuthExtension to prevent:

Fatal error: Class 'Knp\FriendlyContexts\Context\OauthExtension' not found (Behat\Testwork\Call\Exception\FatalThrowableError)