### PR TITLE
Doc ContextApi for specified request body

### DIFF
--- a/doc/context-api.md
+++ b/doc/context-api.md
@@ -57,6 +57,13 @@ Given I specified the following request data:
     | my_form[name] | George ABITBOL |
 # Specified request files for POST requests
     | fileName | path/to/the/file |
+# Specified request raw body, useful for json
+Given I specified the following request body:
+    """
+    {
+        "name": "Peter"
+    }
+    """
 # Specified cookies
 Given I specified the following request cookies:
     | my_option | some data here |


### PR DESCRIPTION
As the ContextApi allows a phrase to post json data (relevent for APIs), the phrase is not in doc.