### PR TITLE
Suggest guzzle/guzzle instead of require it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,16 @@
         "doctrine/data-fixtures": "~1.0",
         "behat/mink-extension": "~2.0",
         "fzaninotto/faker": "~1.4",
-        "nelmio/alice": "~2.0",
-        "guzzle/guzzle": "~3.7"
+        "nelmio/alice": "~2.0"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.4|~3.0",
         "doctrine/orm": "~2.5",
-        "knplabs/phpspec-welldone-extension": "dev-master"
+        "knplabs/phpspec-welldone-extension": "dev-master",
+        "guzzle/guzzle": "~3.7"
+    },
+    "suggest": {
+        "guzzle/guzzle": "To use the Api Context (needs guzzle 3)"
     },
     "license": "MIT",
     "authors": [

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -4,7 +4,7 @@ Installation
 Execute
 
 ```
-composer require knplabs/friendly-contexts dev-master
+composer require knplabs/friendly-contexts
 ```
 
 Edit behat.yml

--- a/doc/context-api.md
+++ b/doc/context-api.md
@@ -1,7 +1,15 @@
 Api Context
 ===========
 
-This context allow you to handle web Api features for your applications. It needs some configuration:
+This context allow you to handle web Api features for your applications.
+
+It has a dependency on `guzzle 3`. You can add it to your project using the following command:
+
+```
+composer require 'guzzle/guzzle' '~3.7'
+```
+
+Then the context needs some configuration:
 
 ```yaml
 default:


### PR DESCRIPTION
The dependency on Guzzle 3 blocks the usage of Symfony 3.

I would like to suggest the package instead of require it as an hard dependency.