### PR TITLE
Remove minimum stability dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,5 @@
     ],
     "config": {
         "bin-dir": "bin"
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
Update of the composer.json to remove minimum stability dev. As FriendlyContext is a library this is useless. Also friendlycontext is used in production by many project. It's time to move on.