### PR TITLE
Add datetimetz to DatetimeGuesser

### DIFF
--- a/spec/Knp/FriendlyContexts/Guesser/DatetimeGuesserSpec.php
+++ b/spec/Knp/FriendlyContexts/Guesser/DatetimeGuesserSpec.php
@@ -44,6 +44,22 @@ class DatetimeGuesserSpec extends ObjectBehavior
         $this->supports($mapping)->shouldReturn(true);
     }
 
+    function it_should_support_datetimetz_mapping_metadata()
+    {
+        $mapping = [
+            'fieldName'  => "created_at",
+            'type'       => "datetimetz",
+            'scale'      => 0,
+            'length'     => null,
+            'unique'     => false,
+            'nullable'   => false,
+            'precision'  => 0,
+            'columnName' => "created_at",
+        ];
+
+        $this->supports($mapping)->shouldReturn(true);
+    } 
+
     function it_should_support_time_mapping_metadata()
     {
         $mapping = [

--- a/src/Knp/FriendlyContexts/Guesser/DatetimeGuesser.php
+++ b/src/Knp/FriendlyContexts/Guesser/DatetimeGuesser.php
@@ -8,7 +8,7 @@ class DatetimeGuesser extends AbstractGuesser implements GuesserInterface
     {
         $mapping = array_merge([ 'type' => null ], $mapping);
 
-        return in_array($mapping['type'], ['datetime', 'date', 'time']);
+        return in_array($mapping['type'], ['datetime', 'datetimetz', 'date', 'time']);
     }
 
     public function transform($str, array $mapping = null)


### PR DESCRIPTION
`datetimetz` is a valid Doctrine type and currently unsupported by the DatetimeGuesser