### PR TITLE
Doctrine JSON type support in entity hydrator class

### DIFF
--- a/src/Knp/FriendlyContexts/Doctrine/EntityHydrator.php
+++ b/src/Knp/FriendlyContexts/Doctrine/EntityHydrator.php
@@ -114,7 +114,7 @@ class EntityHydrator
     {
         $property = $mapping['fieldName'];
         $collectionRelation = in_array($mapping['type'], [ClassMetadata::ONE_TO_MANY, ClassMetadata::MANY_TO_MANY]);
-        $arrayRelation = in_array($mapping['type'], [DBALType::TARRAY, DBALType::SIMPLE_ARRAY, DBALType::JSON_ARRAY]);
+        $arrayRelation = in_array($mapping['type'], [DBALType::TARRAY, DBALType::SIMPLE_ARRAY, DBALType::JSON_ARRAY, DBALType::JSON]);
 
         if ($collectionRelation || $arrayRelation) {
             $result = array_map(


### PR DESCRIPTION
New Doctrine `JSON` data type is now recommended and replaces `JSON_ARRAY`