### PR TITLE
Doctrine JSON type support in entity hydrator class

### DIFF
--- a/src/Knp/FriendlyContexts/Doctrine/EntityHydrator.php
+++ b/src/Knp/FriendlyContexts/Doctrine/EntityHydrator.php
@@ -114,7 +114,7 @@ class EntityHydrator
     {
         $property = $mapping['fieldName'];
         $collectionRelation = in_array($mapping['type'], [ClassMetadata::ONE_TO_MANY, ClassMetadata::MANY_TO_MANY]);
-        $arrayRelation = in_array($mapping['type'], [DBALType::TARRAY, DBALType::SIMPLE_ARRAY, DBALType::JSON_ARRAY]);
+        $arrayRelation = in_array($mapping['type'], [DBALType::TARRAY, DBALType::SIMPLE_ARRAY, DBALType::JSON_ARRAY, DBALType::JSON]);
 
         if ($collectionRelation || $arrayRelation) {
             $result = array_map(


### PR DESCRIPTION
This change adds support for missing `json` [array data type](http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#array-types) in entity hydrator.

Without this `json` entity fields are set as strings. This might causes fatal error if setter method uses type hinting for its argument.