### PR TITLE
Support for creating an instance on entities with constructor in EntityContext

### DIFF
--- a/spec/Knp/FriendlyContexts/Context/EntityContextSpec.php
+++ b/spec/Knp/FriendlyContexts/Context/EntityContextSpec.php
@@ -27,7 +27,7 @@ class EntityContextSpec extends ObjectBehavior
      * @param Knp\FriendlyContexts\Utils\Asserter $asserter
      * @param \ReflectionClass $reflectionClass
      **/
-    function let($container, $doctrine, $manager, $repository, $queryBuilder, $query, $resolver, $bag, $collection, \ReflectionClass $reflectionClass, $asserter, $record1, $record2, $entity1, $entity2, $entity3)
+    public function let($container, $doctrine, $manager, $repository, $queryBuilder, $query, $resolver, $bag, $collection, \ReflectionClass $reflectionClass, $asserter, $record1, $record2, $entity1, $entity2, $entity3)
     {
         $entity1 = 'e1';
         $entity2 = 'e2';
@@ -59,18 +59,18 @@ class EntityContextSpec extends ObjectBehavior
         $this->initialize([], $container);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType('Knp\FriendlyContexts\Context\EntityContext');
     }
 
-    function it_should_assert_a_deletion()
+    public function it_should_assert_a_deletion()
     {
         $this->entitiesShouldHaveBeen('no', 'entities', 'deleted')->shouldReturn(null);
         $this->shouldThrow(new \Exception('2 entities should have been deleted, 0 actually', 1))->duringEntitiesShouldHaveBeen('2', 'entities', 'deleted');
     }
 
-    function it_should_assert_a_creation($collection)
+    public function it_should_assert_a_creation($collection)
     {
         $collection->attach('e1')->shouldNotBeCalled();
         $collection->attach('e2')->shouldNotBeCalled();
@@ -80,7 +80,7 @@ class EntityContextSpec extends ObjectBehavior
         $this->shouldThrow(new \Exception('0 entities should have been created, 1 actually', 1))->duringEntitiesShouldHaveBeen('no', 'entities', 'created');
     }
 
-    function it_should_throw_an_exception_if_no_existence(
+    public function it_should_throw_an_exception_if_no_existence(
         EntityResolver $resolver,
         TableNode $tableNode,
         $repository,

--- a/spec/Knp/FriendlyContexts/Context/EntityContextSpec.php
+++ b/spec/Knp/FriendlyContexts/Context/EntityContextSpec.php
@@ -69,7 +69,8 @@ class EntityContextSpec extends ObjectBehavior
 
     public function it_should_persist_an_entity(ObjectManager $manager, EntityHydrator $entityHydrator, EntityResolver $resolver, ClassMetadata $metadata, TableNode $tableNode)
     {
-        $manager->persist(Argument::type('spec\\Knp\\FriendlyContexts\\Context\\NameEntity'))
+        $instanceOfEntity = Argument::type('spec\\Knp\\FriendlyContexts\\Context\\NameEntity');
+        $manager->persist($instanceOfEntity)
             ->shouldBeCalledTimes(2);
         $manager->flush()
             ->shouldBeCalledTimes(1);
@@ -83,8 +84,12 @@ class EntityContextSpec extends ObjectBehavior
             ['John Doe'],
             ['Jane Doe'],
         ]);
-        $entityHydrator->hydrate($manager, Argument::cetera(), Argument::cetera());
-        $entityHydrator->completeRequired($manager, Argument::cetera());
+        $entityHydrator->hydrate($manager, $instanceOfEntity, ['name' => 'John Doe'])
+            ->shouldBeCalled();
+        $entityHydrator->hydrate($manager, $instanceOfEntity, ['name' => 'Jane Doe'])
+            ->shouldBeCalled();
+        $entityHydrator->completeRequired($manager, $instanceOfEntity)
+            ->shouldBeCalled();
 
         $this->theFollowing('NameEntity', $tableNode);
     }

--- a/spec/Knp/FriendlyContexts/Doctrine/EntityHydratorSpec.php
+++ b/spec/Knp/FriendlyContexts/Doctrine/EntityHydratorSpec.php
@@ -2,24 +2,65 @@
 
 namespace spec\Knp\FriendlyContexts\Doctrine;
 
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\DBAL\Types\Type;
+use Knp\FriendlyContexts\Doctrine\EntityResolver;
+use Knp\FriendlyContexts\Guesser\GuesserManager;
+use Knp\FriendlyContexts\Guesser\GuesserInterface;
+use Knp\FriendlyContexts\Utils\TextFormater;
+use Knp\FriendlyContexts\Utils\UniqueCache;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class EntityHydratorSpec extends ObjectBehavior
 {
     /**
-     * @param Knp\FriendlyContexts\Utils\TextFormater      $formater
+     * @param Knp\FriendlyContexts\Utils\TextFormater      $formatter
      * @param Knp\FriendlyContexts\Guesser\GuesserManager  $manager
      * @param Knp\FriendlyContexts\Doctrine\EntityResolver $resolver
      * @param Knp\FriendlyContexts\Utils\UniqueCache       $uniqueCache
      **/
-    function let($formater, $manager, $resolver, $uniqueCache)
+    public function let(TextFormater $formatter, GuesserManager $manager, EntityResolver $resolver, UniqueCache $uniqueCache)
     {
-        $this->beConstructedWith($formater, $manager, $resolver, $uniqueCache);
+        $this->beConstructedWith($formatter, $manager, $resolver, $uniqueCache);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType('Knp\FriendlyContexts\Doctrine\EntityHydrator');
+    }
+
+    /**
+     * Current design of EntityHydrator::hydrate doesn't allow meaningful testing with PHPSpec
+     */
+    public function it_hydrates_simple_columns(ObjectManager $objectManager, GuesserInterface $guesser, ScalarValuesEntity $e, $manager, $resolver, $formatter)
+    {
+        $entity = new ScalarValuesEntity();
+        $mapping = ['fieldName' => 'foo', 'type' => Type::STRING];
+
+        $guesser->transform('bar', $mapping)->willReturn('bar');
+        $formatter->toCamelCase('foo')->willReturn('foo');
+
+        $manager->find(Argument::any())
+            ->willReturn($guesser);
+        $resolver->getMetadataFromProperty($objectManager, $entity, 'foo')
+            ->willReturn($mapping);
+
+        $this->hydrate($objectManager, $entity, ['foo' => 'bar']);
+    }
+}
+
+class ScalarValuesEntity
+{
+    private $foo;
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
     }
 }

--- a/src/Knp/FriendlyContexts/Context/EntityContext.php
+++ b/src/Knp/FriendlyContexts/Context/EntityContext.php
@@ -20,8 +20,8 @@ class EntityContext extends Context
 
         foreach ($rows as $row) {
             $values     = array_combine($headers, $row);
-            $entity     = new $entityName;
-            $reflection = new \ReflectionClass($entity);
+            $entity     = (new \ReflectionClass($entityName))->newInstanceWithoutConstructor();
+            $reflection = new \ReflectionObject($entity);
 
             do {
                 $this
@@ -32,11 +32,9 @@ class EntityContext extends Context
                 $reflection = $reflection->getParentClass();
             } while (false !== $reflection);
 
-            $this
-                ->getEntityHydrator()
-                ->hydrate($this->getEntityManager(), $entity, $values)
-                ->completeRequired($this->getEntityManager(), $entity)
-            ;
+            $entityHydrator = $this->getEntityHydrator();
+            $entityHydrator->hydrate($this->getEntityManager(), $entity, $values);
+            $entityHydrator->completeRequired($this->getEntityManager(), $entity);
 
             $this->getEntityManager()->persist($entity);
         }


### PR DESCRIPTION
Like already mentioned in #242, it is impossible to test with entities having an constructor. Before, the EntityContext was directly creating an instance with a variable containing the entity full class name. In my PR, I support creating instances of entities with a constructor.

I also added a test for the persist-case of EntityContext, which was missing.